### PR TITLE
feat: update java samples to v1

### DIFF
--- a/samples/snippets/src/main/java/com/example/servicedirectory/EndpointsCreate.java
+++ b/samples/snippets/src/main/java/com/example/servicedirectory/EndpointsCreate.java
@@ -18,9 +18,9 @@ package com.example.servicedirectory;
 
 // [START servicedirectory_create_endpoint]
 
-import com.google.cloud.servicedirectory.v1beta1.Endpoint;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
-import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
 import java.io.IOException;
 
 public class EndpointsCreate {

--- a/samples/snippets/src/main/java/com/example/servicedirectory/EndpointsDelete.java
+++ b/samples/snippets/src/main/java/com/example/servicedirectory/EndpointsDelete.java
@@ -18,8 +18,8 @@ package com.example.servicedirectory;
 
 // [START servicedirectory_delete_endpoint]
 
-import com.google.cloud.servicedirectory.v1beta1.EndpointName;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
 import java.io.IOException;
 
 public class EndpointsDelete {

--- a/samples/snippets/src/main/java/com/example/servicedirectory/NamespacesCreate.java
+++ b/samples/snippets/src/main/java/com/example/servicedirectory/NamespacesCreate.java
@@ -18,9 +18,9 @@ package com.example.servicedirectory;
 
 // [START servicedirectory_create_namespace]
 
-import com.google.cloud.servicedirectory.v1beta1.LocationName;
-import com.google.cloud.servicedirectory.v1beta1.Namespace;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
 import java.io.IOException;
 
 public class NamespacesCreate {

--- a/samples/snippets/src/main/java/com/example/servicedirectory/NamespacesDelete.java
+++ b/samples/snippets/src/main/java/com/example/servicedirectory/NamespacesDelete.java
@@ -18,8 +18,8 @@ package com.example.servicedirectory;
 
 // [START servicedirectory_delete_namespace]
 
-import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
 import java.io.IOException;
 
 public class NamespacesDelete {

--- a/samples/snippets/src/main/java/com/example/servicedirectory/Quickstart.java
+++ b/samples/snippets/src/main/java/com/example/servicedirectory/Quickstart.java
@@ -18,10 +18,10 @@ package com.example.servicedirectory;
 
 // [START servicedirectory_quickstart]
 
-import com.google.cloud.servicedirectory.v1beta1.LocationName;
-import com.google.cloud.servicedirectory.v1beta1.Namespace;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient.ListNamespacesPagedResponse;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient.ListNamespacesPagedResponse;
 import java.io.IOException;
 
 public class Quickstart {

--- a/samples/snippets/src/main/java/com/example/servicedirectory/ServicesCreate.java
+++ b/samples/snippets/src/main/java/com/example/servicedirectory/ServicesCreate.java
@@ -18,9 +18,9 @@ package com.example.servicedirectory;
 
 // [START servicedirectory_create_service]
 
-import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
-import com.google.cloud.servicedirectory.v1beta1.Service;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.Service;
 import java.io.IOException;
 
 public class ServicesCreate {
@@ -49,15 +49,15 @@ public class ServicesCreate {
       NamespaceName parent = NamespaceName.of(projectId, locationId, namespaceId);
 
       // The service object to create.
-      // Optionally add some metadata for the service.
-      Service service = Service.newBuilder().putMetadata("protocol", "tcp").build();
+      // Optionally add some annotations for the service.
+      Service service = Service.newBuilder().putAnnotations("protocol", "tcp").build();
 
       // Send the request to create the namespace.
       Service createdService = client.createService(parent, service, serviceId);
 
       // Process the response.
       System.out.println("Created Service: " + createdService.getName());
-      System.out.println("Metadata: " + createdService.getMetadata());
+      System.out.println("Annotations: " + createdService.getAnnotations());
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/servicedirectory/ServicesDelete.java
+++ b/samples/snippets/src/main/java/com/example/servicedirectory/ServicesDelete.java
@@ -18,8 +18,8 @@ package com.example.servicedirectory;
 
 // [START servicedirectory_delete_service]
 
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
-import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.ServiceName;
 import java.io.IOException;
 
 public class ServicesDelete {

--- a/samples/snippets/src/main/java/com/example/servicedirectory/ServicesResolve.java
+++ b/samples/snippets/src/main/java/com/example/servicedirectory/ServicesResolve.java
@@ -18,11 +18,11 @@ package com.example.servicedirectory;
 
 // [START servicedirectory_resolve_service]
 
-import com.google.cloud.servicedirectory.v1beta1.Endpoint;
-import com.google.cloud.servicedirectory.v1beta1.LookupServiceClient;
-import com.google.cloud.servicedirectory.v1beta1.ResolveServiceRequest;
-import com.google.cloud.servicedirectory.v1beta1.ResolveServiceResponse;
-import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.cloud.servicedirectory.v1.Endpoint;
+import com.google.cloud.servicedirectory.v1.LookupServiceClient;
+import com.google.cloud.servicedirectory.v1.ResolveServiceRequest;
+import com.google.cloud.servicedirectory.v1.ResolveServiceResponse;
+import com.google.cloud.servicedirectory.v1.ServiceName;
 import java.io.IOException;
 
 public class ServicesResolve {

--- a/samples/snippets/src/test/java/com/example/servicedirectory/EndpointsTests.java
+++ b/samples/snippets/src/test/java/com/example/servicedirectory/EndpointsTests.java
@@ -19,11 +19,11 @@ package com.example.servicedirectory;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import com.google.cloud.servicedirectory.v1beta1.EndpointName;
-import com.google.cloud.servicedirectory.v1beta1.LocationName;
-import com.google.cloud.servicedirectory.v1beta1.Namespace;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient.ListNamespacesPagedResponse;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient.ListNamespacesPagedResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.UUID;

--- a/samples/snippets/src/test/java/com/example/servicedirectory/NamespacesTests.java
+++ b/samples/snippets/src/test/java/com/example/servicedirectory/NamespacesTests.java
@@ -19,11 +19,11 @@ package com.example.servicedirectory;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import com.google.cloud.servicedirectory.v1beta1.LocationName;
-import com.google.cloud.servicedirectory.v1beta1.Namespace;
-import com.google.cloud.servicedirectory.v1beta1.NamespaceName;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient.ListNamespacesPagedResponse;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.NamespaceName;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient.ListNamespacesPagedResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.UUID;

--- a/samples/snippets/src/test/java/com/example/servicedirectory/ServicesTests.java
+++ b/samples/snippets/src/test/java/com/example/servicedirectory/ServicesTests.java
@@ -19,12 +19,12 @@ package com.example.servicedirectory;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import com.google.cloud.servicedirectory.v1beta1.EndpointName;
-import com.google.cloud.servicedirectory.v1beta1.LocationName;
-import com.google.cloud.servicedirectory.v1beta1.Namespace;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient;
-import com.google.cloud.servicedirectory.v1beta1.RegistrationServiceClient.ListNamespacesPagedResponse;
-import com.google.cloud.servicedirectory.v1beta1.ServiceName;
+import com.google.cloud.servicedirectory.v1.EndpointName;
+import com.google.cloud.servicedirectory.v1.LocationName;
+import com.google.cloud.servicedirectory.v1.Namespace;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient;
+import com.google.cloud.servicedirectory.v1.RegistrationServiceClient.ListNamespacesPagedResponse;
+import com.google.cloud.servicedirectory.v1.ServiceName;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.UUID;


### PR DESCRIPTION
As our GA date approaches, we want the samples in our docs to use the v1 version of our API rather than the v1beta1 version.

Example here: https://cloud.google.com/service-directory/docs/configuring-service-directory#servicedirectory_create_namespace-java
